### PR TITLE
Make menu buttons clickable everywhere.

### DIFF
--- a/Web/app/components/Menu/MenuItem.js
+++ b/Web/app/components/Menu/MenuItem.js
@@ -7,11 +7,8 @@ export default class MenuItem extends React.Component{
 	}
 	render(){
 		return(
-			<div>
-				<div className="menuItem">
-					<div className="circle"/>
-					<Link to={"/" + this.props.label} className='menuLink'>{this.props.label}</Link>
-				</div>
+			<div className="menuItem">
+				<Link to={"/" + this.props.label} className='menuLink'>{this.props.label}</Link>
 			</div>
 		)
 	}

--- a/Web/app/sass/_menusass.scss
+++ b/Web/app/sass/_menusass.scss
@@ -71,7 +71,8 @@
 	height: 100px;
 }
 
-.menuItem {
+.menuItem a {
+	display: block;
 	position: static;
 	margin: 5px;
 	background: #444444;
@@ -81,14 +82,22 @@
 	justify-content: center;
 	height: 50px;
 	width: 100px;
+	text-decoration: none;
 
-	a {
-		color: #FFFFFF;
-		text-decoration: none;
+	::before {
+		position: absolute;
+		bottom: 25px;
+
+		@include bottomRadialGradient(#efab34, #444444, 100%);
+
+		width: 100px;
+		height: 15px;
+		opacity: 0;
+		transition: all 0.5s;
 	}
 
 	&:hover {
-		.circle {
+		::before {
 			transition: opacity 0.3s;
 			opacity: 0.75;
 		}
@@ -97,18 +106,6 @@
 		 * font-weight: bold
 		 * letter-spacing: 0.2px */
 	}
-}
-
-.circle {
-	position: absolute;
-	bottom: 25px;
-
-	@include bottomRadialGradient(#efab34, #444444, 100%);
-
-	width: 100px;
-	height: 15px;
-	opacity: 0;
-	transition: all 0.5s;
 }
 
 .menuLink {


### PR DESCRIPTION
- Remove the wrapper `div` from menu items
- Move `.menuItem` styling to the `a`
- `display: block` the links
- Move the circle hover effect to a pseudo-element